### PR TITLE
Fix #13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,5 @@
 ## 1.1.1
 
 - Corrected display of crew tab in ships to display for English
+- Updated crew tab for ships to allow any crew spot to have an actor added
+- Updated roll dialog for ship attacks to not include location

--- a/template/chat/roll.html
+++ b/template/chat/roll.html
@@ -54,7 +54,11 @@
             <h1>{{name}}</h1>
         {{/unless}}
         {{#each damages as |damage|}}
+            {{#if hasLocation}}
             <h3 class="separator damage-location" data-location={{location}}>{{localize location}}</h3>
+            {{else}}
+            <h3></h3>
+            {{/if}}
             <div>
                 <p><strong>{{localize "CHAT.DAMAGE"}}:</strong> <span class="damage-total">{{damage.total}}</span> 
                    <strong class="damage-type">{{damageTypeShort ../damageType}}</strong>


### PR DESCRIPTION
Created a ship damage roll function that does not use location when creating a damage roll. Created a flag for location to allow the roll dialog to suppress location if it is not provided. 